### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/datadog-synthetics.yml
+++ b/.github/workflows/datadog-synthetics.yml
@@ -12,6 +12,8 @@
 # 2. Start using the action within your workflow
 
 name: Run Datadog Synthetic tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/Motor-de-Recomendacion-Gastronomica/security/code-scanning/1](https://github.com/santiagourdaneta/Motor-de-Recomendacion-Gastronomica/security/code-scanning/1)

To fix the issue, a `permissions` block should be added to the workflow to restrict the GITHUB_TOKEN permissions, following the principle of least privilege. Since this workflow does not seem to require write access to repository contents—its primary purpose is to run Datadog Synthetic tests—it suffices to set `contents: read` permissions at the workflow level (above `jobs:`), ensuring all jobs only have the ability to read repository contents, and not to write. This change should be placed after the `name:` key (line 14) and before `on:` (line 16), following common YAML patterns in GitHub Actions workflows.

No new imports, methods, or definitions are required; only the addition of the `permissions` block to the workflow YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
